### PR TITLE
Fix touch cancelled bug

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -121,6 +121,7 @@ public protocol ActiveLabelDelegate: class {
             }
             avoidSuperCall = true
         case .Cancelled:
+            updateAttributesWhenSelected(false)
             selectedElement = nil
         case .Stationary:
             break


### PR DESCRIPTION
Fix a bug where the label does not return to the default URL color when the UITouch is cancelled.