### PR TITLE
WWIOS-2373 Forums - Unable to copy text from discussion title, discussion message, and comment message

### DIFF
--- a/ActiveLabel/ActiveLabel.swift
+++ b/ActiveLabel/ActiveLabel.swift
@@ -560,7 +560,7 @@ typealias ElementTuple = (range: NSRange, element: ActiveElement, type: ActiveTy
     }
     
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if action == #selector(NSObject.copy) {
+        if action == #selector(copy(_:)) {
             return true
         }
         return false


### PR DESCRIPTION
WWIOS-2373 
Forums - Unable to copy text from discussion title, discussion message, and comment message

### changes
- uses correct method selector for copying of label's text

https://weddingwire.atlassian.net/browse/WWIOS-2373